### PR TITLE
Fix Civi requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create and display walkthrough tutorials for CiviCRM screens.
 
 ## Requirements
 
-* CiviCRM 4.7+
+* CiviCRM 5.7+
 
 ## Usage
 

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.0</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>5.7</ver>
   </compatibility>
   <comments>Support this extension by donating to CiviCRM!</comments>
   <civix>


### PR DESCRIPTION
Civix is still doing 4.7 as a default - we should update that - but  in this case we definitely
should have the version this was developed against not an old version which it may well not work seamlessly against